### PR TITLE
Autorole Refactor

### DIFF
--- a/commands/autorole.js
+++ b/commands/autorole.js
@@ -1,76 +1,94 @@
-const Command = require('../structures/command.js');
+const Command    = require('../structures/command.js');
+const SubCommand = require('../structures/subcommand.js');
 
 module.exports = class Autorole extends Command {
 
   constructor(client) {
     super(client);
 
-    this.name    = "autorole";
-    this.aliases = ["ar"];
+    this.name        = "autorole";
+    this.aliases     = ["ar", "autoroles"];
+    this.subcommands = [new AutoroleClear(client, this)];
   }
 
-  run(message, args, commandLang, databases, lang) {
-    let embed = this.client.getDekuEmbed(message);
-    let db = databases.autorole_config;
-    if (args[0]) {
+  async run(message, args, commandLang, databases, lang) {
+    let embed      = this.client.getDekuEmbed(message).setColor(this.client.config.colors.error);
+    let autoroleDB = databases.autorole_config;
+    
+    let autorole;
+    try        { autorole = await autoroleDB.getPromise(message.guild.id) }
+    catch(err) { autorole = {} }
+    
+    if (args.length > 0) {
       if (message.member.hasPermission('MANAGE_GUILD')) {
-        if (args[0] == '--clear') {
-          db.del(message.guild.id, (err) => {
-            if (!err) {
-              embed.setColor(this.client.config.colors.success);
-              embed.setDescription(commandLang.clear_success);
-              message.channel.send({embed});
-            } else {
-              embed.setColor(this.client.config.colors.error);
-              embed.setDescription(commandLang.clear_error.replace('{0}', err));
-              message.channel.send({embed});
-            }
-          });
-        } else {
-          if (message.guild.roles.get(args[0])) {
-            var type = 'everyone';
-            if (args[1] == '--bots') type = 'bots';
-            db.get(message.guild.id, (err, value) => {
-              if (!value) value = "{}";
-              value = JSON.parse(value);
-              value[type] = args[0];
-              db.put(message.guild.id, JSON.stringify(value), (err) => {
-                if (!err) {
-                  embed.setColor(this.client.config.colors.success);
-                  if (type == 'everyone') embed.setDescription(commandLang.db_put_success.replace('{0}', message.guild.roles.get(args[0])));
-                  if (type == 'bots') embed.setDescription(commandLang.db_put_success_bots.replace('{0}', message.guild.roles.get(args[0])));
-                  message.channel.send({embed});
-                } else {
-                  embed.setColor(this.client.config.colors.error);
-                  embed.setDescription(commandLang.db_put_error);
-                  message.channel.send({embed});
-                }
-              });
-            });
-          } else {
-            embed.setColor(this.client.config.colors.error);
-            embed.setTitle(commandLang.inexistent_role.replace('{0}', args[0]));
-            embed.setDescription(`\u200b\n${lang.usage} \`${commandLang._usage}\`\n${lang.example} \`${commandLang._example}\``);
-            embed.setFooter(commandLang.pro_tip);
-            message.channel.send({embed});
+        let role = message.guild.roles.get(args[0]);
+        if (role) {
+          let type = args[1] == '--bots' ? 'bots' : 'everyone';
+          autorole[type] = role.id;
+          
+          try {
+            await autoroleDB.putPromise(message.guild.id, autorole);
+            
+            let text = type == 'bots' ? commandLang.db_put_success_bots : commandLang.db_put_success;
+            embed.setColor(this.client.config.colors.success);
+            embed.setDescription(text.replace('{0}', role));
+          } catch(err) {
+            embed.setDescription(commandLang.db_put_error);
           }
+        } else {
+          embed.setTitle(commandLang.inexistent_role.replace('{0}', args[0]));
+          embed.setDescription(`\u200b\n${lang.usage} \`${commandLang._usage}\`\n${lang.example} \`${commandLang._example}\``);
+          embed.setFooter(commandLang.pro_tip);
         }
       } else {
         embed.setColor(this.client.config.colors.error);
         embed.setDescription(commandLang.no_permission);
-        message.channel.send({embed});
       }
     } else {
-      embed.setColor(this.client.config.colors.error);
-      embed.setTitle(commandLang.no_args);
-      embed.setDescription(`\u200b\n${lang.usage} \`${commandLang._usage}\`\n${lang.example} \`${commandLang._example}\``);
-      embed.setFooter(commandLang.pro_tip);
-      message.channel.send({embed});
+      if(!autorole || Object.keys(autorole).length < 1) {
+        embed.setDescription(commandLang.no_roles);
+      } else {
+        if(autorole['bots'])     embed.addField(commandLang.bots_role, message.guild.roles.get(autorole['bots']), true);
+        if(autorole['everyone']) embed.addField(commandLang.everyone_role, message.guild.roles.get(autorole['everyone']), true);
+      }
     }
+    
+    message.channel.send({embed});
   }
 
   canRun(message, args) {
     return message.guild ? true : false;
+  }
+
+}
+
+
+// d!autorole --clear
+class AutoroleClear extends SubCommand {
+
+  constructor(client, parentCommand) {
+    super(client, parentCommand);
+
+    this.name    = "clear";
+    this.aliases = ["--clear"];
+  }
+
+  async run(message, args, commandLang, databases, lang) {
+    let embed = this.client.getDekuEmbed(message).setColor(this.client.config.colors.error);
+    if (message.member.hasPermission('MANAGE_GUILD')) {
+      let autoroleDB = databases.autorole_config;
+      try {
+        await autoroleDB.delPromise(message.guild.id);
+        embed.setColor(this.client.config.colors.success);
+        embed.setDescription(commandLang.clear_success);
+      } catch(err) {
+        embed.setDescription(commandLang.clear_error.replace('{0}', err));
+      }
+    } else {
+      embed.setDescription(commandLang.no_permission);
+    }
+    
+    message.channel.send({embed});
   }
 
 }

--- a/commands/roleme.js
+++ b/commands/roleme.js
@@ -157,7 +157,7 @@ class RoleMeRemove extends SubCommand {
             embed.setDescription(commandLang.not_roleme.replace('{0}', roleName));
           }
         } else {
-          embed.setDescription(commandLang.no_roleme_roles);
+          embed.setDescription(commandLang.no_roles);
         }
       } else {
         embed.setTitle(commandLang.insuficcient_args_remove);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const config    = require('./config.json');
-const Deku      = require('./deku.js');
-const client    = new Deku({config});
+const config = require('./config.json');
+const Deku   = require('./deku.js');
+const client = new Deku({config});
 client.start();
 
 // Express Server for /docs testing

--- a/translation/en_US.json
+++ b/translation/en_US.json
@@ -101,10 +101,9 @@
             "insuficcient_args_remove": "You need to specify a role name!",
             "add_usage": "**Usage:** `d!roleme --add <role name> <role id>`\n**Example:** `d!roleme --add lol 358446520334286851`\n\nPro tip: You can get the role IDs from d!roleids",
             "remove_usage": "**Usage:** `d!roleme --remove <role name>`\n**Example:** `d!roleme --remove lol`",
-            "no_roles": "This server doesen't have `d!roleme` roles.",
+            "no_roles": "This server doesn't have `d!roleme` roles.",
             "remove_success": "I removed `{0}` from the `d!roleme` roles.",
             "not_roleme": "`{0}` isn't a `d!roleme` role.",
-            "no_roleme_roles": "This server doesen't have `d!roleme` roles.",
             "command": "Command",
             "role": "Role",
             "heres_a_list": "Here's a list of avaliable roles:",
@@ -213,7 +212,10 @@
             "no_args": "You need to specify a role ID!",
             "inexistent_role": "`{0}` isn't a valid role ID for this server.",
             "clear_success": "I cleared the default roles.",
-            "clear_error": "Something went wrong while clearing the default roles.\n\n`{0}`If you think this is a bug, please report it using `d!bugreport`"
+            "clear_error": "Something went wrong while clearing the default roles.\n\n`{0}`If you think this is a bug, please report it using `d!bugreport`",
+            "no_roles": "This server doesn't have autoroles.",
+            "everyone_role": "Members role",
+            "bots_role": "Bots role"
         },
         "translate": {
             "_usage": "d!translate [--desiredlanguage] <your text>",

--- a/utils.js
+++ b/utils.js
@@ -2,18 +2,12 @@ const level = require('level');
 
 module.exports = {
   
-  arrayToStringWithCommas: (array, last) => {
-    var string = "";
-    for (i = 0; i < array.length; i++) {
-      if (i == (array.length - 1)) {
-        string = string + array[i];
-      } else if (i == (array.length - 2)) {
-        string = string + array[i] + last;
-      } else {
-        string = string + array[i] + ", ";
-      }
-    }
-    return string;
+  arrayToStringWithCommas: (array, and) => {
+    if(!array || !Array.isArray(array) || array.length < 1) return '';
+    if(array.length < 2) return array[0];
+    let lastIndex = array.length - 1;
+    let firstPart = array.slice(0, lastIndex).join(', ');
+    return firstPart + and + array[lastIndex];
   },
   
   initializeDatabase: (path) => {
@@ -25,9 +19,9 @@ module.exports = {
           if(err) {
             reject(err);
           } else {
-            try { res = JSON.parse(res) }
-            catch(e) {}
-            resolve(res);
+            try      { res = JSON.parse(res); }
+            catch(e) { res = res || {};       }
+            finally  { resolve(res);          }
           }
         });
       });
@@ -37,6 +31,15 @@ module.exports = {
       if(typeof value !== 'string') value = JSON.stringify(value);
       return new Promise((resolve, reject) => {
         db.put(key, value, (err) => {
+          if(err) reject(err);
+          else    resolve();
+        });
+      });
+    }
+    
+    db.delPromise = (key) => {
+      return new Promise((resolve, reject) => {
+        db.del(key, (err) => {
           if(err) reject(err);
           else    resolve();
         });


### PR DESCRIPTION
- Refactors autorole to use subcommands (only `--clear`).
- [Show default roles when ran without arguments.](https://trello.com/c/xMZGI2K5/46-show-default-roles-when-dautoroles-is-ran-without-arguments)

#### Other fixes:

- [Fixes d!roleme `no_roles` typo.](https://trello.com/c/2pVXkFv6/95-typo-in-the-two-this-server-doesent-have-droleme-roles-string-it-says-doesent-instead-of-doesnt)
- Improves `arrayToStringWithCommas`.
- Use of `db.getPromise`, `db.putPromise` and `db.delPromise` to asynchronize command.
- Remove unused `no_roleme_roles` key from en_US.json file. (I don't know if I should edit the others files.)