### PR TITLE
Add say command with support for embeds

### DIFF
--- a/commands/say.js
+++ b/commands/say.js
@@ -1,0 +1,59 @@
+const Command = require('../structures/command.js');
+const SubCommand = require('../structures/subcommand.js');
+
+module.exports = class Say extends Command {
+
+  constructor(client) {
+    super(client);
+    this.name = "say";
+    this.subcommands = [new EmbedSay(client, this)];
+  }
+
+  run(message, args, commandLang, databases, lang) {
+    if (message.member.hasPermission('MANAGE_GUILD')) {
+      message.channel.send(args.join(' '));
+      message.delete();
+    } else {
+      var embed = this.client.getDekuEmbed(message);
+      embed.setDescription(lang.missing_manageguild_permission);
+      embed.setColor(this.client.config.colors.error);
+      message.channel.send(embed);
+    }
+  }
+
+}
+
+class EmbedSay extends SubCommand {
+  constructor(client, parentCommand) {
+    super(client, parentCommand);
+
+    this.name    = "embed";
+    this.aliases = ["--embed"];
+  }
+
+  async run(message, args, commandLang, databases, lang) {
+    if (message.member.hasPermission('MANAGE_GUILD')) {
+      try {
+        var json = JSON.parse(args.join(' '));
+      } catch (e) {
+        var embed = this.client.getDekuEmbed(message);
+        embed.setColor(this.client.config.colors.error);
+        embed.setTitle(commandLang.json_error_title);
+        embed.setDescription(commandLang.json_error_desc);
+        message.channel.send(embed);
+        return;
+      }
+      message.delete();
+      if (json.content) {
+        message.channel.send(json.content, json);
+      } else {
+        message.channel.send(json);
+      }
+    } else {
+      var embed = this.client.getDekuEmbed(message);
+      embed.setDescription(lang.missing_manageguild_permission);
+      embed.setColor(this.client.config.colors.error);
+      message.channel.send(embed);
+    }
+  };
+}

--- a/translation/en_US.json
+++ b/translation/en_US.json
@@ -251,8 +251,16 @@
           "_description": "Creates a TogetherTube room.",
           "error_title": "An error ocurred while creating the room.",
           "error_description": "Please report this using `d!bugreport`"
+        },
+        "say": {
+          "_usage": "d!say <text|--embed <json>>",
+          "_description": "Forces the bot to say something.",
+          "_example": "d!say Hello World",
+          "json_error_title": "An error ocurred while parsing your JSON.",
+          "json_error_desc": "You can use leovel's [embed visualizer](https://leovoel.github.io/embed-visualizer/) to check what's wrong."
         }
     },
+    "missing_manageguild_permission": "You need the **\"Manage Guild**\" permission in order to do this",
     "usage": "**Usage:**",
     "example": "**Example:**"
 }


### PR DESCRIPTION
Adds `d!say`.

**Usage:** `d!say d!say <text|--embed <json>>`

**Examples:**
- `d!say Hello World` - The bot will say "Hello World"
- `d!say embed {"content": "Hello", "embed": {"title": "World"}}` - The bot will send a message saying "Hello" and an embed with the title "World" 
![image](https://user-images.githubusercontent.com/25179120/31590755-a40cc504-b1f4-11e7-8b58-5cfd89d9980e.png)
