### PR TITLE
Fix avatar help text

### DIFF
--- a/commands/playing.js
+++ b/commands/playing.js
@@ -11,7 +11,7 @@ module.exports = class Playing extends Command {
   run(message, args, commandLang) {
     let embed = this.client.getDekuEmbed(message);
     if(args[0]) {
-      let game = args[0];
+      let game = args.join(' ');
       let count = message.guild.members.filterArray(m => m.user.presence.game && m.user.presence.game.name.toLowerCase() == game.toLowerCase()).length;
       let text = count == 0 ? commandLang.zero : count == 1 ? commandLang.one : commandLang.more;
       text = text.replace('{0}', game).replace('{1}', count);

--- a/translation/en_US.json
+++ b/translation/en_US.json
@@ -169,6 +169,8 @@
             "trying_to_stop": "trying to stop typing..."
         },
         "avatar": {
+            "_description": "Shows yours or someone's profile picture in full size",
+            "_usage": "d!avatar [user]",
             "own_picture": "here's your profile picture:",
             "someones_picture": "here's **{0}**'s profile picture:"
         },


### PR DESCRIPTION
### Changes:
- [The help text for d!avatar doesen't show "undefined" anymore.](https://trello.com/c/2aUsEras/79-dhelp-shows-davatars-description-and-usage-as-null)