### PR TITLE
Add GenerateInvite command (d!generateinvite)

### DIFF
--- a/commands/generateinvite.js
+++ b/commands/generateinvite.js
@@ -17,7 +17,7 @@ module.exports = class BugReport extends Command {
       message.channel.startTyping();
       let channel = message.member.voiceChannel ? message.member.voiceChannel : message.channel;
       channel.createInvite({options: options}, lang.reason).then(invite => {
-          embed.setTitle(commandLang.heres_your_invite.replace('{0}', channel.name)).setDescription('http://discord.gg/' + invite.code);
+          embed.setTitle(commandLang.heres_your_invite.replace('{0}', channel.name)).setDescription(invite.url);
           message.channel.send(embed);
           message.channel.stopTyping();
       });

--- a/commands/generateinvite.js
+++ b/commands/generateinvite.js
@@ -1,0 +1,36 @@
+const Command = require('../structures/command.js');
+
+module.exports = class BugReport extends Command {
+
+  constructor(client) {
+    super(client);
+    this.name    = "generateinvite";
+    this.aliases = ["geninvite", "geninv", "gi", "invitegen"];
+  }
+
+  run(message, args, commandLang, databases, lang) {
+    let embed = this.client.getDekuEmbed(message);
+    let options = {
+      unique: true
+    }
+    if (message.member.hasPermission('CREATE_INSTANT_INVITE')) {
+      message.channel.startTyping();
+      let channel = message.member.voiceChannel ? message.member.voiceChannel : message.channel;
+      channel.createInvite({options: options}, lang.reason).then(invite => {
+          embed.setTitle(commandLang.heres_your_invite.replace('{0}', channel.name)).setDescription('http://discord.gg/' + invite.code);
+          message.channel.send(embed);
+          message.channel.stopTyping();
+      });
+    } else {
+      embed.setTitle(lang.missing_invite_permission);
+      embed.setColor(this.client.config.colors.error);
+      message.channel.send(embed);
+    }
+
+  }
+
+}
+
+// Config flags
+// disable-command:generateinvite
+// generateinvite-cmd:allow-anyone

--- a/translation/en_US.json
+++ b/translation/en_US.json
@@ -273,9 +273,15 @@
           "invalid_zone": "Invalid zone.",
           "current": "Current Temperature:",
           "temperature_before": "{0}ºC with {1}% of air humidity and {2} air speed."
+        },
+        "generateinvite": {
+          "_usage": "d!generateinvite",
+          "_description": "Generates an instant invite to the current text or voice channel.",
+          "heres_your_invite": "Here's your invite link for \"{0}\""
         }
     },
     "missing_manageguild_permission": "You need the **\"Manage Guild**\" permission in order to do this",
+    "missing_invite_permission": "You need the **\"Create Instant Invites**\" permission in order to do this",
     "usage": "**Usage:**",
     "example": "**Example:**"
 }

--- a/translation/en_US.json
+++ b/translation/en_US.json
@@ -286,5 +286,5 @@
     "missing_manageguild_permission": "You need the **\"Manage Guild**\" permission in order to do this",
     "missing_invite_permission": "You need the **\"Create Instant Invites**\" permission in order to do this",
     "usage": "**Usage:**",
-    "example": "**Example:**",
+    "example": "**Example:**"
 }


### PR DESCRIPTION
# New command: d!generateinvite
Suggested by **Kuroi#0303**

**Usage:** `d!generateinvite`
**Description:** Generates an invite link for the current text or voice channel.

- If you're in a voice channel, it will generate an invite for that channel. Otherwise, an invite link for the text channel where the command was executed will be generated.
- Only works if you have the `CREATE_INSTANT_INVITE` permission.